### PR TITLE
[Security] Add retrieval of encompassing role names

### DIFF
--- a/src/Symfony/Component/Security/Core/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Core/CHANGELOG.md
@@ -2,6 +2,11 @@ CHANGELOG
 =========
 
 
+7.1
+---
+
+* Add `getEncompassingRoleNames` method to `RoleHierarchyInterface`
+
 7.0
 ---
 

--- a/src/Symfony/Component/Security/Core/Role/RoleHierarchy.php
+++ b/src/Symfony/Component/Security/Core/Role/RoleHierarchy.php
@@ -50,6 +50,22 @@ class RoleHierarchy implements RoleHierarchyInterface
         return array_values(array_unique($reachableRoles));
     }
 
+    public function getEncompassingRoleNames(array $roles): array
+    {
+        $encompassingRoles = $roles;
+
+        foreach ($roles as $role) {
+            foreach ($this->map as $parent => $children) {
+                if (in_array($role, $children)) {
+                    $encompassingRoles[] = $parent;
+                }
+
+            }
+        }
+
+        return array_values(array_unique($encompassingRoles));
+    }
+
     protected function buildRoleMap(): void
     {
         $this->map = [];

--- a/src/Symfony/Component/Security/Core/Role/RoleHierarchyInterface.php
+++ b/src/Symfony/Component/Security/Core/Role/RoleHierarchyInterface.php
@@ -14,6 +14,8 @@ namespace Symfony\Component\Security\Core\Role;
 /**
  * RoleHierarchyInterface is the interface for a role hierarchy.
  *
+ * @method array getEncompassingRoleNames(array $roles)
+ *
  * @author Fabien Potencier <fabien@symfony.com>
  */
 interface RoleHierarchyInterface

--- a/src/Symfony/Component/Security/Core/Tests/Role/RoleHierarchyTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Role/RoleHierarchyTest.php
@@ -30,4 +30,21 @@ class RoleHierarchyTest extends TestCase
         $this->assertEquals(['ROLE_SUPER_ADMIN', 'ROLE_ADMIN', 'ROLE_FOO', 'ROLE_USER'], $role->getReachableRoleNames(['ROLE_SUPER_ADMIN']));
         $this->assertEquals(['ROLE_SUPER_ADMIN', 'ROLE_ADMIN', 'ROLE_FOO', 'ROLE_USER'], $role->getReachableRoleNames(['ROLE_SUPER_ADMIN', 'ROLE_SUPER_ADMIN']));
     }
+
+    public function testGetEncompassingRoleNames()
+    {
+        $role = new RoleHierarchy([
+            'ROLE_ADMIN' => ['ROLE_USER'],
+            'ROLE_SUPER_ADMIN' => ['ROLE_ADMIN', 'ROLE_FOO'],
+            'ROLE_USER' => ['ROLE_BAR'],
+        ]);
+
+        $this->assertEquals(['ROLE_SUPER_ADMIN'], $role->getEncompassingRoleNames(['ROLE_SUPER_ADMIN']));
+        $this->assertEquals(['ROLE_ADMIN', 'ROLE_SUPER_ADMIN'], $role->getEncompassingRoleNames(['ROLE_ADMIN']));
+        $this->assertEquals(['ROLE_USER', 'ROLE_ADMIN', 'ROLE_SUPER_ADMIN'], $role->getEncompassingRoleNames(['ROLE_USER']));
+        $this->assertEquals(['ROLE_BAR', 'ROLE_ADMIN', 'ROLE_SUPER_ADMIN', 'ROLE_USER'], $role->getEncompassingRoleNames(['ROLE_BAR']));
+        $this->assertEquals(['ROLE_SUPER_ADMIN'], $role->getEncompassingRoleNames(['ROLE_SUPER_ADMIN', 'ROLE_SUPER_ADMIN']));
+        $this->assertEquals(['ROLE_SUPER_ADMIN', 'ROLE_USER', 'ROLE_ADMIN'], $role->getEncompassingRoleNames(['ROLE_SUPER_ADMIN', 'ROLE_USER']));
+        $this->assertEquals(['ROLE_BAR', 'ROLE_FOO','ROLE_ADMIN', 'ROLE_SUPER_ADMIN', 'ROLE_USER'], $role->getEncompassingRoleNames(['ROLE_BAR', 'ROLE_FOO']));
+    }
 }


### PR DESCRIPTION
The aim of this method is to provide a handy way of getting the roles that encompass (or are parent of) an array of roles.

It is similar to the `RoleHierarchyInterface::getReachableRoleNames(array $roles)` but instead of retrieving the roles and children roles it retrieves the roles and parent roles.

A typical use case would be when we get a user role from a database and need to get all the roles that also have access to whatever this role can access.

| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| License       | MIT


Also what do you guys think of renaming  the existing`getReachableRoleNames` (that retrieves the "children roles" of an array of roles) as well as `getEncompassingRoleNames` (that retrieves the "parent roles" of an array of roles) to `getParentRoles`  and  `getChildrenRoles` in order to better reflect their intention ? 

For the sake of this PR I tried to use a naming that is consistent with the existing `getReachableRoleNames`  method.
